### PR TITLE
docs: add exported types section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,4 +37,3 @@ pnpm format:ci          # Prettier check
 pnpm storybook          # dev server on port 6006
 pnpm storybook:build    # build static storybook site
 ```
-

--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ const node = findNode(root, 'm3w');
 const path = pathToNode(root, 'm3w'); // [root, m1w, m1b, m2w, m2b, m3w]
 ```
 
+## Exported types
+
+| Type             | Description                                                                                              |
+| ---------------- | -------------------------------------------------------------------------------------------------------- |
+| `Eval`           | `{ type: 'cp' \| 'mate'; value: number; depth?: number }` — engine evaluation                            |
+| `MoveNode`       | Tree node representing a single move, with id, san, side, children, and optional eval/comment/nags/clock |
+| `MoveSheetProps` | All props accepted by `<MoveSheet />`                                                                    |
+
+```tsx
+import type { Eval, MoveNode, MoveSheetProps } from '@echecs/react-movesheet';
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- added exported types section documenting `Eval`, `MoveNode`, `MoveSheetProps` as importable types