### PR TITLE
fix: replace hard-coded font styles with CSS variables

### DIFF
--- a/src/move-sheet.tsx
+++ b/src/move-sheet.tsx
@@ -401,9 +401,9 @@ function MoveSheet({
 
   const containerStyle: CSSProperties = {
     background: 'var(--movesheet-background, transparent)',
-    fontFamily: 'sans-serif',
-    fontSize: '14px',
-    lineHeight: '1.6',
+    fontFamily: 'var(--movesheet-font-family, inherit)',
+    fontSize: 'var(--movesheet-font-size, inherit)',
+    lineHeight: 'var(--movesheet-line-height, 1.6)',
     overflow: 'auto',
   };
 


### PR DESCRIPTION
## Summary

- replaces hard-coded `fontFamily: 'sans-serif'` and `fontSize: '14px'` with `--movesheet-font-family` and `--movesheet-font-size` CSS variables, defaulting to `inherit`
- adds `--movesheet-line-height` variable (default `1.6`) for consistency with other `--movesheet-*` tokens
- consumers can now control typography from parent elements or via CSS variables

closes #2