### PR TITLE
feat: add onContextMenu prop for right-click move selection

### DIFF
--- a/src/__tests__/move-sheet.spec.tsx
+++ b/src/__tests__/move-sheet.spec.tsx
@@ -185,6 +185,30 @@ describe('MoveSheet click interactions', () => {
 
     expect(onSelectMove).toHaveBeenCalledWith('m1b');
   });
+
+  it('calls onContextMenu with correct move ID on right-click', () => {
+    const onContextMenu = vi.fn();
+    render(<MoveSheet game={simpleGame} onContextMenu={onContextMenu} />);
+
+    const moveSpan = document.querySelector('[data-move-id="m1w"]');
+    expect(moveSpan).toBeInTheDocument();
+    fireEvent.contextMenu(moveSpan!);
+
+    expect(onContextMenu).toHaveBeenCalledWith('m1w');
+  });
+
+  it('does not prevent default when onContextMenu is not provided', () => {
+    render(<MoveSheet game={simpleGame} />);
+
+    const moveSpan = document.querySelector('[data-move-id="m1w"]');
+    expect(moveSpan).toBeInTheDocument();
+
+    const event = new MouseEvent('contextmenu', { bubbles: true });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+    moveSpan!.dispatchEvent(event);
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('MoveSheet keyboard navigation', () => {

--- a/src/move-sheet.tsx
+++ b/src/move-sheet.tsx
@@ -41,6 +41,7 @@ interface RenderNodeOptions {
   depth: number;
   isFirstInVariation: boolean;
   node: MoveNode;
+  onContextMenu: ((moveId: string) => void) | undefined;
   onSelectMove: ((moveId: string) => void) | undefined;
   showClock: boolean;
   showComments: boolean;
@@ -54,6 +55,7 @@ function renderNode(options: RenderNodeOptions): ReactNode[] {
     depth,
     isFirstInVariation,
     node,
+    onContextMenu,
     onSelectMove,
     showClock,
     showComments,
@@ -103,6 +105,14 @@ function renderNode(options: RenderNodeOptions): ReactNode[] {
       onClick={() => {
         onSelectMove?.(node.id);
       }}
+      onContextMenu={
+        onContextMenu
+          ? (event) => {
+              event.preventDefault();
+              onContextMenu(node.id);
+            }
+          : undefined
+      }
       style={moveStyle}
     >
       {node.san}
@@ -165,6 +175,7 @@ function renderNode(options: RenderNodeOptions): ReactNode[] {
     const variationElements = renderVariation({
       currentMoveId,
       depth: depth + 1,
+      onContextMenu,
       onSelectMove,
       showClock,
       showComments,
@@ -194,6 +205,7 @@ function renderNode(options: RenderNodeOptions): ReactNode[] {
 interface RenderVariationOptions {
   currentMoveId: string | undefined;
   depth: number;
+  onContextMenu: ((moveId: string) => void) | undefined;
   onSelectMove: ((moveId: string) => void) | undefined;
   showClock: boolean;
   showComments: boolean;
@@ -206,6 +218,7 @@ function renderVariation(options: RenderVariationOptions): ReactNode[] {
   const {
     currentMoveId,
     depth,
+    onContextMenu,
     onSelectMove,
     showClock,
     showComments,
@@ -224,6 +237,7 @@ function renderVariation(options: RenderVariationOptions): ReactNode[] {
       depth,
       isFirstInVariation: isFirst && current.side === 'black',
       node: current,
+      onContextMenu,
       onSelectMove,
       showClock,
       showComments,
@@ -256,6 +270,7 @@ function MoveSheet({
   currentMoveId,
   game,
   keyboard = true,
+  onContextMenu,
   onSelectMove,
   showClock = false,
   showComments = true,
@@ -409,6 +424,7 @@ function MoveSheet({
 
   const content = renderMainLine({
     currentMoveId,
+    onContextMenu,
     onSelectMove,
     root,
     showClock,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ interface MoveSheetProperties {
   currentMoveId?: string;
   game: PGN;
   keyboard?: boolean;
+  onContextMenu?: (moveId: string) => void;
   onSelectMove?: (moveId: string) => void;
   showClock?: boolean;
   showComments?: boolean;


### PR DESCRIPTION
## Summary

- adds `onContextMenu?: (moveId: string) => void` prop that fires on right-click, calling `preventDefault` to suppress the browser menu
- threaded through main line, variations, and nested variations — same path as `onSelectMove`
- when not provided, right-click behaves normally (no `preventDefault`)
- includes 2 new tests covering callback invocation and default behavior

closes #3