### PR TITLE
fix: expose comment display and font-style as CSS variables

### DIFF
--- a/src/move-sheet.tsx
+++ b/src/move-sheet.tsx
@@ -150,7 +150,8 @@ function renderNode(options: RenderNodeOptions): ReactNode[] {
         key={`${node.id}-comment`}
         style={{
           color: 'var(--movesheet-comment, #666)',
-          fontStyle: 'italic',
+          display: 'var(--movesheet-comment-display, inline)',
+          fontStyle: 'var(--movesheet-comment-font-style, italic)',
         }}
       >
         {node.comment}


### PR DESCRIPTION
## Summary

- adds `--movesheet-comment-display` CSS variable (default `inline`) — set to `block` to render comments on their own line
- adds `--movesheet-comment-font-style` CSS variable (default `italic`) — lets consumers override the hard-coded italic style
- no new props — consistent with the existing `--movesheet-*` theming approach

closes #4