### PR TITLE
release: @echecs/react-movesheet@0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.2.0 — 2026-04-19
+
+### Added
+
+- `onContextMenu` prop — fires on right-click with the move ID, for annotation
+  workflows that need to distinguish navigation from selection (#3)
+- `--movesheet-font-family` CSS variable (default `inherit`)
+- `--movesheet-font-size` CSS variable (default `inherit`)
+- `--movesheet-line-height` CSS variable (default `1.6`)
+- `--movesheet-comment-display` CSS variable (default `inline`) — set to `block`
+  for block-level comments
+- `--movesheet-comment-font-style` CSS variable (default `italic`)
+
+### Fixed
+
+- `fontFamily` and `fontSize` were hard-coded inline and couldn't be overridden
+  by consumers (#2)
+- comment `fontStyle` was hard-coded to `italic` with no override (#4)
+
 ## 0.1.2 — 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ export function App() {
 | `game`           | `PGN`                      | required    | Parsed PGN game from `@echecs/pgn` |
 | `currentMoveId`  | `string`                   | `undefined` | ID of the currently active move    |
 | `onSelectMove`   | `(moveId: string) => void` | —           | Called when a move is clicked      |
+| `onContextMenu`  | `(moveId: string) => void` | —           | Called on right-click of a move    |
 | `showComments`   | `boolean`                  | `true`      | Show inline comment text           |
 | `showEvaluation` | `boolean`                  | `false`     | Show engine evaluation after moves |
 | `showNags`       | `boolean`                  | `true`      | Show NAG glyphs (!, ?, !!, ??)     |
@@ -101,16 +102,21 @@ All colours are controlled via CSS custom properties on a parent element:
 </div>
 ```
 
-| Variable                  | Default       | Description           |
-| ------------------------- | ------------- | --------------------- |
-| `--movesheet-background`  | `transparent` | Panel background      |
-| `--movesheet-active-move` | `#d4e8ff`     | Active move bg        |
-| `--movesheet-move-text`   | `inherit`     | Move SAN colour       |
-| `--movesheet-move-number` | `inherit`     | Move number colour    |
-| `--movesheet-comment`     | `#666`        | Comment text colour   |
-| `--movesheet-nag`         | `inherit`     | NAG glyph colour      |
-| `--movesheet-evaluation`  | `gray`        | Eval text colour      |
-| `--movesheet-variation`   | `#888`        | Variation text colour |
+| Variable                         | Default       | Description           |
+| -------------------------------- | ------------- | --------------------- |
+| `--movesheet-background`         | `transparent` | Panel background      |
+| `--movesheet-active-move`        | `#d4e8ff`     | Active move bg        |
+| `--movesheet-move-text`          | `inherit`     | Move SAN colour       |
+| `--movesheet-move-number`        | `inherit`     | Move number colour    |
+| `--movesheet-comment`            | `#666`        | Comment text colour   |
+| `--movesheet-comment-display`    | `inline`      | Comment display mode  |
+| `--movesheet-comment-font-style` | `italic`      | Comment font style    |
+| `--movesheet-font-family`        | `inherit`     | Panel font family     |
+| `--movesheet-font-size`          | `inherit`     | Panel font size       |
+| `--movesheet-line-height`        | `1.6`         | Panel line height     |
+| `--movesheet-nag`                | `inherit`     | NAG glyph colour      |
+| `--movesheet-evaluation`         | `gray`        | Eval text colour      |
+| `--movesheet-variation`          | `#888`        | Variation text colour |
 
 ## Utilities
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echecs/react-movesheet",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "license": "MIT",
   "description": "React move notation panel — displays chess game moves with click navigation, variations, comments, NAGs, evaluation, and keyboard navigation.",


### PR DESCRIPTION
## Summary

- **feat:** `onContextMenu` prop for right-click move selection (#3)
- **fix:** font styles now use `--movesheet-font-family`, `--movesheet-font-size`, `--movesheet-line-height` CSS variables instead of hard-coded inline values (#2)
- **fix:** comment display and font-style exposed as `--movesheet-comment-display`, `--movesheet-comment-font-style` CSS variables (#4)
- updated CHANGELOG.md and README.md