### PR TITLE
feat: enable storybook autodocs with prop descriptions

### DIFF
--- a/src/__stories__/move-sheet.stories.tsx
+++ b/src/__stories__/move-sheet.stories.tsx
@@ -28,6 +28,7 @@ const meta: Meta<MoveSheetProperties> = {
       </div>
     ),
   ],
+  tags: ['autodocs'],
   title: 'MoveSheet',
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,14 +22,23 @@ interface MoveNode {
 }
 
 interface MoveSheetProperties {
+  /** ID of the move to highlight as the current position. */
   currentMoveId?: string;
+  /** Parsed PGN game object to display. */
   game: PGN;
+  /** Enable arrow-key navigation (Right/Left, Up/Down for variations, Home/End). */
   keyboard?: boolean;
+  /** Called when a move is right-clicked. Receives the move ID. */
   onContextMenu?: (moveId: string) => void;
+  /** Called when a move is clicked. Receives the move ID. */
   onSelectMove?: (moveId: string) => void;
+  /** Show clock annotations next to moves. */
   showClock?: boolean;
+  /** Show inline text comments. */
   showComments?: boolean;
+  /** Show evaluation annotations (centipawn or mate). */
   showEvaluation?: boolean;
+  /** Show Numeric Annotation Glyphs (!, ?, !!, etc.). */
   showNags?: boolean;
 }
 


### PR DESCRIPTION
## Summary

- adds `tags: ['autodocs']` to story meta — generates a docs page with interactive prop table
- adds JSDoc comments to all `MoveSheetProperties` fields so autodocs renders descriptions