### PR TITLE
move @echecs/pgn from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,12 +46,11 @@
     "node": ">=20"
   },
   "peerDependencies": {
+    "@echecs/pgn": "^4.0.0",
     "react": ">=18"
   },
-  "dependencies": {
-    "@echecs/pgn": "^3.10.1"
-  },
   "devDependencies": {
+    "@echecs/pgn": "^4.0.0",
     "@eslint/js": "^10.0.1",
     "@storybook/react-vite": "^10.3.4",
     "@testing-library/jest-dom": "^6.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,10 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@echecs/pgn':
-        specifier: ^3.10.1
-        version: 3.12.2
     devDependencies:
+      '@echecs/pgn':
+        specifier: ^4.0.0
+        version: 4.0.0
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
@@ -241,8 +240,8 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@echecs/pgn@3.12.2':
-    resolution: {integrity: sha512-AuRu1uMjocizipvdfkSmuJXBgrE5JkBNqP0Nhbl5dpyatChCnOgr6h1m+8w60dbeTXE/KnFz4Xh+QgZrnajaaw==}
+  '@echecs/pgn@4.0.0':
+    resolution: {integrity: sha512-m47TtW6Y5+VovhXct61X0p5o5WKFo7Evz37Sq4adSPf2DlgvbH8wiMPdp6j0JrwhcV/JCwXMqGVoHy5LrHFHbA==}
     engines: {node: '>=20'}
 
   '@emnapi/core@1.10.0':
@@ -2608,7 +2607,7 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@echecs/pgn@3.12.2': {}
+  '@echecs/pgn@4.0.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:

--- a/src/__tests__/move-sheet.spec.tsx
+++ b/src/__tests__/move-sheet.spec.tsx
@@ -17,8 +17,12 @@ function makeMove(
 }
 
 const simpleGame = makePGN([
-  [1, makeMove({ piece: 'P', to: 'e4' }), makeMove({ piece: 'P', to: 'e5' })],
-  [2, makeMove({ piece: 'N', to: 'f3' }), undefined],
+  [
+    1,
+    makeMove({ piece: 'pawn', to: 'e4' }),
+    makeMove({ piece: 'pawn', to: 'e5' }),
+  ],
+  [2, makeMove({ piece: 'knight', to: 'f3' }), undefined],
 ]);
 
 describe('MoveSheet rendering', () => {
@@ -50,7 +54,11 @@ describe('MoveSheet rendering', () => {
 
   it('renders comments when showComments is true (default)', () => {
     const gameWithComment = makePGN([
-      [1, makeMove({ comment: 'Kings pawn', piece: 'P', to: 'e4' }), undefined],
+      [
+        1,
+        makeMove({ comment: 'Kings pawn', piece: 'pawn', to: 'e4' }),
+        undefined,
+      ],
     ]);
     render(<MoveSheet game={gameWithComment} />);
 
@@ -59,7 +67,11 @@ describe('MoveSheet rendering', () => {
 
   it('hides comments when showComments is false', () => {
     const gameWithComment = makePGN([
-      [1, makeMove({ comment: 'Kings pawn', piece: 'P', to: 'e4' }), undefined],
+      [
+        1,
+        makeMove({ comment: 'Kings pawn', piece: 'pawn', to: 'e4' }),
+        undefined,
+      ],
     ]);
     render(<MoveSheet game={gameWithComment} showComments={false} />);
 
@@ -68,7 +80,7 @@ describe('MoveSheet rendering', () => {
 
   it('renders NAG glyphs when showNags is true (default)', () => {
     const gameWithNag = makePGN([
-      [1, makeMove({ annotations: ['1'], piece: 'P', to: 'e4' }), undefined],
+      [1, makeMove({ annotations: ['1'], piece: 'pawn', to: 'e4' }), undefined],
     ]);
     render(<MoveSheet game={gameWithNag} />);
 
@@ -77,7 +89,7 @@ describe('MoveSheet rendering', () => {
 
   it('hides NAGs when showNags is false', () => {
     const gameWithNag = makePGN([
-      [1, makeMove({ annotations: ['1'], piece: 'P', to: 'e4' }), undefined],
+      [1, makeMove({ annotations: ['1'], piece: 'pawn', to: 'e4' }), undefined],
     ]);
     render(<MoveSheet game={gameWithNag} showNags={false} />);
 
@@ -88,7 +100,7 @@ describe('MoveSheet rendering', () => {
     const gameWithEval = makePGN([
       [
         1,
-        makeMove({ eval: { type: 'cp', value: 35 }, piece: 'P', to: 'e4' }),
+        makeMove({ eval: { type: 'cp', value: 35 }, piece: 'pawn', to: 'e4' }),
         undefined,
       ],
     ]);
@@ -101,7 +113,7 @@ describe('MoveSheet rendering', () => {
     const gameWithMate = makePGN([
       [
         1,
-        makeMove({ eval: { type: 'mate', value: 3 }, piece: 'P', to: 'e4' }),
+        makeMove({ eval: { type: 'mate', value: 3 }, piece: 'pawn', to: 'e4' }),
         undefined,
       ],
     ]);
@@ -114,7 +126,7 @@ describe('MoveSheet rendering', () => {
     const gameWithEval = makePGN([
       [
         1,
-        makeMove({ eval: { type: 'cp', value: 35 }, piece: 'P', to: 'e4' }),
+        makeMove({ eval: { type: 'cp', value: 35 }, piece: 'pawn', to: 'e4' }),
         undefined,
       ],
     ]);
@@ -125,7 +137,7 @@ describe('MoveSheet rendering', () => {
 
   it('renders clock when showClock is true', () => {
     const gameWithClock = makePGN([
-      [1, makeMove({ clock: 3661, piece: 'P', to: 'e4' }), undefined],
+      [1, makeMove({ clock: 3661, piece: 'pawn', to: 'e4' }), undefined],
     ]);
     render(<MoveSheet game={gameWithClock} showClock={true} />);
 
@@ -134,7 +146,7 @@ describe('MoveSheet rendering', () => {
 
   it('hides clock when showClock is false (default)', () => {
     const gameWithClock = makePGN([
-      [1, makeMove({ clock: 3661, piece: 'P', to: 'e4' }), undefined],
+      [1, makeMove({ clock: 3661, piece: 'pawn', to: 'e4' }), undefined],
     ]);
     render(<MoveSheet game={gameWithClock} />);
 
@@ -145,14 +157,14 @@ describe('MoveSheet rendering', () => {
 describe('MoveSheet variations', () => {
   it('renders variation moves', () => {
     const whiteMove2: Move = {
-      ...makeMove({ piece: 'N', to: 'f3' }),
-      variants: [[[2, makeMove({ piece: 'P', to: 'd4' }), undefined]]],
+      ...makeMove({ piece: 'knight', to: 'f3' }),
+      variants: [[[2, makeMove({ piece: 'pawn', to: 'd4' }), undefined]]],
     };
     const gameWithVariation = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [2, whiteMove2, undefined],
     ]);
@@ -278,14 +290,14 @@ describe('MoveSheet keyboard navigation', () => {
 
   it('ArrowDown enters variation from parent move', () => {
     const whiteMove2: Move = {
-      ...makeMove({ piece: 'N', to: 'f3' }),
-      variants: [[[2, makeMove({ piece: 'P', to: 'd4' }), undefined]]],
+      ...makeMove({ piece: 'knight', to: 'f3' }),
+      variants: [[[2, makeMove({ piece: 'pawn', to: 'd4' }), undefined]]],
     };
     const gameWithVariation = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [2, whiteMove2, undefined],
     ]);
@@ -308,14 +320,14 @@ describe('MoveSheet keyboard navigation', () => {
 
   it('ArrowDown cycles to next sibling variation', () => {
     const whiteMove2: Move = {
-      ...makeMove({ piece: 'N', to: 'f3' }),
-      variants: [[[2, makeMove({ piece: 'P', to: 'd4' }), undefined]]],
+      ...makeMove({ piece: 'knight', to: 'f3' }),
+      variants: [[[2, makeMove({ piece: 'pawn', to: 'd4' }), undefined]]],
     };
     const gameWithVariation = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [2, whiteMove2, undefined],
     ]);
@@ -338,14 +350,14 @@ describe('MoveSheet keyboard navigation', () => {
 
   it('ArrowUp exits variation (jumps to move before the fork)', () => {
     const whiteMove2: Move = {
-      ...makeMove({ piece: 'N', to: 'f3' }),
-      variants: [[[2, makeMove({ piece: 'P', to: 'd4' }), undefined]]],
+      ...makeMove({ piece: 'knight', to: 'f3' }),
+      variants: [[[2, makeMove({ piece: 'pawn', to: 'd4' }), undefined]]],
     };
     const gameWithVariation = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [2, whiteMove2, undefined],
     ]);

--- a/src/__tests__/notation.spec.ts
+++ b/src/__tests__/notation.spec.ts
@@ -4,66 +4,81 @@ import { nagToSymbol, toSAN } from '../notation.js';
 
 import type { Move } from '../types.js';
 
+function makeMove(
+  partial: Partial<Move> & { piece: Move['piece']; to: Move['to'] },
+): Move {
+  return partial as Move;
+}
+
 describe('toSAN', () => {
   it('renders a pawn move', () => {
-    const move: Move = { piece: 'P', to: 'e4' };
-    expect(toSAN(move)).toBe('e4');
+    expect(toSAN(makeMove({ piece: 'pawn', to: 'e4' }))).toBe('e4');
   });
 
   it('renders a piece move', () => {
-    const move: Move = { piece: 'N', to: 'f3' };
-    expect(toSAN(move)).toBe('Nf3');
+    expect(toSAN(makeMove({ piece: 'knight', to: 'f3' }))).toBe('Nf3');
   });
 
   it('renders a capture', () => {
-    const move: Move = { capture: true, from: 'e', piece: 'P', to: 'd5' };
-    expect(toSAN(move)).toBe('exd5');
+    expect(
+      toSAN(makeMove({ capture: true, from: 'e', piece: 'pawn', to: 'd5' })),
+    ).toBe('exd5');
   });
 
   it('renders a piece capture', () => {
-    const move: Move = { capture: true, piece: 'B', to: 'c6' };
-    expect(toSAN(move)).toBe('Bxc6');
+    expect(toSAN(makeMove({ capture: true, piece: 'bishop', to: 'c6' }))).toBe(
+      'Bxc6',
+    );
   });
 
   it('renders disambiguation', () => {
-    const move: Move = { from: 'a', piece: 'R', to: 'd1' };
-    expect(toSAN(move)).toBe('Rad1');
+    expect(toSAN(makeMove({ from: 'a', piece: 'rook', to: 'd1' }))).toBe(
+      'Rad1',
+    );
   });
 
   it('renders kingside castling', () => {
-    const move: Move = { castling: true, piece: 'K', to: 'g1' };
-    expect(toSAN(move)).toBe('O-O');
+    expect(toSAN(makeMove({ castling: true, piece: 'king', to: 'g1' }))).toBe(
+      'O-O',
+    );
   });
 
   it('renders queenside castling', () => {
-    const move: Move = { castling: true, piece: 'K', to: 'c1' };
-    expect(toSAN(move)).toBe('O-O-O');
+    expect(toSAN(makeMove({ castling: true, piece: 'king', to: 'c1' }))).toBe(
+      'O-O-O',
+    );
   });
 
   it('renders check', () => {
-    const move: Move = { check: true, piece: 'Q', to: 'h7' };
-    expect(toSAN(move)).toBe('Qh7+');
+    expect(toSAN(makeMove({ check: true, piece: 'queen', to: 'h7' }))).toBe(
+      'Qh7+',
+    );
   });
 
   it('renders checkmate', () => {
-    const move: Move = { checkmate: true, piece: 'Q', to: 'h7' };
-    expect(toSAN(move)).toBe('Qh7#');
+    expect(toSAN(makeMove({ checkmate: true, piece: 'queen', to: 'h7' }))).toBe(
+      'Qh7#',
+    );
   });
 
   it('renders promotion', () => {
-    const move: Move = { piece: 'P', promotion: 'Q', to: 'e8' };
-    expect(toSAN(move)).toBe('e8=Q');
+    expect(
+      toSAN(makeMove({ piece: 'pawn', promotion: 'queen', to: 'e8' })),
+    ).toBe('e8=Q');
   });
 
   it('renders capture + promotion', () => {
-    const move: Move = {
-      capture: true,
-      from: 'd',
-      piece: 'P',
-      promotion: 'Q',
-      to: 'e8',
-    };
-    expect(toSAN(move)).toBe('dxe8=Q');
+    expect(
+      toSAN(
+        makeMove({
+          capture: true,
+          from: 'd',
+          piece: 'pawn',
+          promotion: 'queen',
+          to: 'e8',
+        }),
+      ),
+    ).toBe('dxe8=Q');
   });
 });
 

--- a/src/__tests__/tree.spec.ts
+++ b/src/__tests__/tree.spec.ts
@@ -31,13 +31,13 @@ describe('buildTree', () => {
     const game = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [
         2,
-        makeMove({ piece: 'N', to: 'f3' }),
-        makeMove({ piece: 'N', to: 'c6' }),
+        makeMove({ piece: 'knight', to: 'f3' }),
+        makeMove({ piece: 'knight', to: 'c6' }),
       ],
     ]);
     const root = buildTree(game);
@@ -72,7 +72,9 @@ describe('buildTree', () => {
   });
 
   it('handles white-only move pair', () => {
-    const game = makePGN([[1, makeMove({ piece: 'P', to: 'e4' }), undefined]]);
+    const game = makePGN([
+      [1, makeMove({ piece: 'pawn', to: 'e4' }), undefined],
+    ]);
     const root = buildTree(game);
 
     expect(root.children).toHaveLength(1);
@@ -82,7 +84,9 @@ describe('buildTree', () => {
   });
 
   it('handles black-only first pair (white is undefined)', () => {
-    const game = makePGN([[1, undefined, makeMove({ piece: 'P', to: 'e5' })]]);
+    const game = makePGN([
+      [1, undefined, makeMove({ piece: 'pawn', to: 'e5' })],
+    ]);
     const root = buildTree(game);
 
     expect(root.children).toHaveLength(1);
@@ -96,7 +100,7 @@ describe('buildTree', () => {
     const move = makeMove({
       annotations: ['1', '6'],
       comment: 'Strong move',
-      piece: 'P',
+      piece: 'pawn',
       to: 'e4',
     });
     const game = makePGN([[1, move, undefined]]);
@@ -108,7 +112,7 @@ describe('buildTree', () => {
   });
 
   it('does not set nags when annotations is undefined', () => {
-    const move = makeMove({ piece: 'N', to: 'f3' });
+    const move = makeMove({ piece: 'knight', to: 'f3' });
     const game = makePGN([[1, move, undefined]]);
     const root = buildTree(game);
 
@@ -119,7 +123,7 @@ describe('buildTree', () => {
   it('transfers eval from Move to MoveNode', () => {
     const move = makeMove({
       eval: { depth: 20, type: 'cp', value: 35 },
-      piece: 'P',
+      piece: 'pawn',
       to: 'e4',
     });
     const game = makePGN([[1, move, undefined]]);
@@ -130,7 +134,7 @@ describe('buildTree', () => {
   });
 
   it('transfers clock from Move to MoveNode', () => {
-    const move = makeMove({ clock: 120, piece: 'P', to: 'e4' });
+    const move = makeMove({ clock: 120, piece: 'pawn', to: 'e4' });
     const game = makePGN([[1, move, undefined]]);
     const root = buildTree(game);
 
@@ -143,17 +147,17 @@ describe('buildTree', () => {
     // Nf3 has 2 variants: d4 and Bc4
     // All three are children of m1b
     const whiteMove2: Move = {
-      ...makeMove({ piece: 'N', to: 'f3' }),
+      ...makeMove({ piece: 'knight', to: 'f3' }),
       variants: [
-        [[2, makeMove({ piece: 'P', to: 'd4' }), undefined]],
-        [[2, makeMove({ piece: 'B', to: 'c4' }), undefined]],
+        [[2, makeMove({ piece: 'pawn', to: 'd4' }), undefined]],
+        [[2, makeMove({ piece: 'bishop', to: 'c4' }), undefined]],
       ],
     };
     const game = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [2, whiteMove2, undefined],
     ]);
@@ -181,20 +185,20 @@ describe('buildTree', () => {
     // Nf3's first variation is d4, and d4 itself has a sub-variation c4.
     // c4 is an alternative to d4, so it attaches to d4's parent (m1b).
     // Final m1b.children: [Nf3 (m2w), d4 (m2w-v0-m2w), c4 (m2w-v0-m2w-v0-m2w)]
-    const innerVariant: Move = makeMove({ piece: 'P', to: 'c4' });
+    const innerVariant: Move = makeMove({ piece: 'pawn', to: 'c4' });
     const d4Move: Move = {
-      ...makeMove({ piece: 'P', to: 'd4' }),
+      ...makeMove({ piece: 'pawn', to: 'd4' }),
       variants: [[[2, innerVariant, undefined]]],
     };
     const nf3Move: Move = {
-      ...makeMove({ piece: 'N', to: 'f3' }),
+      ...makeMove({ piece: 'knight', to: 'f3' }),
       variants: [[[2, d4Move, undefined]]],
     };
     const game = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [2, nf3Move, undefined],
     ]);
@@ -217,8 +221,8 @@ describe('buildTree', () => {
     const game = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
     ]);
     const root = buildTree(game);
@@ -242,8 +246,8 @@ describe('findNode', () => {
     const game = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
     ]);
     const root = buildTree(game);
@@ -256,14 +260,14 @@ describe('findNode', () => {
 
   it('finds a variation node', () => {
     const whiteMove2: Move = {
-      ...makeMove({ piece: 'N', to: 'f3' }),
-      variants: [[[2, makeMove({ piece: 'P', to: 'd4' }), undefined]]],
+      ...makeMove({ piece: 'knight', to: 'f3' }),
+      variants: [[[2, makeMove({ piece: 'pawn', to: 'd4' }), undefined]]],
     };
     const game = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [2, whiteMove2, undefined],
     ]);
@@ -295,8 +299,8 @@ describe('pathToNode', () => {
     const game = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
     ]);
     const root = buildTree(game);
@@ -309,14 +313,14 @@ describe('pathToNode', () => {
 
   it('returns full path for a variation node', () => {
     const whiteMove2: Move = {
-      ...makeMove({ piece: 'N', to: 'f3' }),
-      variants: [[[2, makeMove({ piece: 'P', to: 'd4' }), undefined]]],
+      ...makeMove({ piece: 'knight', to: 'f3' }),
+      variants: [[[2, makeMove({ piece: 'pawn', to: 'd4' }), undefined]]],
     };
     const game = makePGN([
       [
         1,
-        makeMove({ piece: 'P', to: 'e4' }),
-        makeMove({ piece: 'P', to: 'e5' }),
+        makeMove({ piece: 'pawn', to: 'e4' }),
+        makeMove({ piece: 'pawn', to: 'e5' }),
       ],
       [2, whiteMove2, undefined],
     ]);

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -2,6 +2,14 @@ import type { Move } from './types.js';
 
 const KINGSIDE_SQUARES = new Set(['g1', 'g8']);
 
+const PIECE_LETTER: Record<string, string> = {
+  bishop: 'B',
+  king: 'K',
+  knight: 'N',
+  queen: 'Q',
+  rook: 'R',
+};
+
 const NAG_SYMBOLS: Record<string, string> = {
   '1': '!',
   '2': '?',
@@ -28,20 +36,20 @@ function nagToSymbol(nag: string): string {
 function toSAN(move: Move): string {
   if (move.castling) {
     return applyIndicators(
-      KINGSIDE_SQUARES.has(move.to) ? 'O-O' : 'O-O-O',
+      move.to !== undefined && KINGSIDE_SQUARES.has(move.to) ? 'O-O' : 'O-O-O',
       move,
     );
   }
 
   let san = '';
 
-  if (move.piece === 'P') {
+  if (move.piece === 'pawn') {
     san += move.capture ? (move.from ?? '') + 'x' + move.to : move.to;
     if (move.promotion !== undefined) {
-      san += '=' + move.promotion;
+      san += '=' + PIECE_LETTER[move.promotion];
     }
   } else {
-    san += move.piece;
+    san += PIECE_LETTER[move.piece] ?? move.piece;
     if (move.from !== undefined) {
       san += move.from;
     }


### PR DESCRIPTION
## Summary
- moved `@echecs/pgn` from `dependencies` to `peerDependencies` + `devDependencies` at `^4.0.0`
- adapted `toSAN()` in `notation.ts` for pgn v4's `PieceType` union (full words instead of single letters)
- updated all test fixtures to match the new type shape

closes #37