### PR TITLE
release: @echecs/react-movesheet@0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.3.0 — 2026-05-01
+
+### Changed
+
+- `@echecs/pgn` moved from `dependencies` to `peerDependencies` at `^4.0.0`,
+  matching the pattern used by `@echecs/tiebreak` and `@echecs/san` (#37)
+- internal SAN rendering adapted for pgn v4's `PieceType` union
+
+### Added
+
+- storybook autodocs with prop descriptions (#11)
+
 ## 0.2.0 — 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install @echecs/react-movesheet
 pnpm add @echecs/react-movesheet
 ```
 
-React >=18 is a peer dependency.
+`react` >=18 and `@echecs/pgn` >=4 are peer dependencies.
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echecs/react-movesheet",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "license": "MIT",
   "description": "React move notation panel — displays chess game moves with click navigation, variations, comments, NAGs, evaluation, and keyboard navigation.",


### PR DESCRIPTION
## Summary
- `@echecs/pgn` moved from `dependencies` to `peerDependencies` at `^4.0.0`
- storybook autodocs with prop descriptions
- internal SAN rendering adapted for pgn v4
- README updated to list both peer dependencies