### PR TITLE
chore: align lint-staged config

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  '*.(css|js|json|jsx|md|mjs|mts|ts|tsx|yml|yaml)': ['prettier --write'],
+  '*': ['prettier --write --ignore-unknown'],
   '*.(js|jsx|mjs|mts|ts|tsx)': [
     'eslint --fix --max-warnings 0 --no-warn-ignored',
   ],


### PR DESCRIPTION
uses glob * with --ignore-unknown instead of explicit extension list