### PR TITLE
chore: remove unnecessary main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "/dist/",


### PR DESCRIPTION
ESM-only package with exports — main is a CJS-era field that is not needed