### PR TITLE
chore: normalize types field path

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "/dist/",
     "LICENSE",


### PR DESCRIPTION
uses relative ./dist/index.d.ts path consistently across all packages