### PR TITLE
chore: update homepage to echecs.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/echecsjs/react-movesheet.git"
   },
-  "homepage": "https://github.com/echecsjs/react-movesheet#readme",
+  "homepage": "https://react-movesheet.echecs.dev",
   "bugs": {
     "url": "https://github.com/echecsjs/react-movesheet/issues"
   },


### PR DESCRIPTION
points homepage to the docs site instead of the github repo