### PR TITLE
chore: add missing husky hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm run format:ci && pnpm run lint:ci && pnpm run test:coverage


### PR DESCRIPTION
adds `pre-commit` and `pre-push` husky hooks — were missing from this package